### PR TITLE
Handle symbolic links

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,25 +1,41 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
 use crate::cli::Args;
 use crate::filter::FileFilter;
 use crate::stats::Statistics;
 
-/// Represents a node in the file system tree.
+/// Represents the type of a file system node
+pub enum NodeType {
+    File,
+    Directory,
+    SymbolicLink,
+}
+
+/// Represents a node in the file system tree
 ///
 /// Each `TreeNode` contains information about a file or directory, including its name,
-/// path, whether it is a directory, its size (if applicable), and its children nodes
-/// (if it is a directory).
+/// path, type, size (if applicable), and its children nodes (if it is a directory).
 pub struct TreeNode {
     pub name: String,
     pub path: std::path::PathBuf,
-    pub is_dir: bool,
+    pub node_type: NodeType,
     pub size: Option<u64>,
     pub children: Vec<TreeNode>,
 }
 
+/// The builder responsible for constructing a file system tree based on the provided command line arguments
 pub struct TreeBuilder<'a> {
+    /// The command line arguments used to configure the tree building process
     pub args: &'a Args,
-    file_filter: FileFilter,
-    pub stats: Statistics,
+    /// The root path from which the tree is built
     root: std::path::PathBuf,
+    /// The file filter used to determine which files and directories to include in the tree
+    file_filter: FileFilter,
+    /// A set of visited paths to avoid processing the same path multiple times
+    visited: HashSet<PathBuf>,
+    /// The statistics collected during the tree building process
+    pub stats: Statistics,
 }
 
 impl<'a> TreeBuilder<'a> {
@@ -30,15 +46,30 @@ impl<'a> TreeBuilder<'a> {
             args,
             file_filter: FileFilter::new(args)?,
             stats: Statistics::default(),
+            visited: HashSet::new(),
         })
     }
 
     /// Builds a `TreeNode` representing the file system structure starting from the given path.
     pub fn build<P: AsRef<std::path::Path>>(&mut self, path: P) -> std::io::Result<TreeNode> {
         let path = path.as_ref();
-        let metadata = std::fs::metadata(path)?;
-        let is_dir = metadata.is_dir();
-        let size = if !is_dir { Some(metadata.len()) } else { None };
+        let metadata = std::fs::symlink_metadata(path)?;
+
+        let file_type = metadata.file_type();
+        let node_type = if file_type.is_dir() {
+            NodeType::Directory
+        } else if file_type.is_symlink() {
+            NodeType::SymbolicLink
+        } else {
+            NodeType::File
+        };
+
+        let size = if !metadata.is_dir() {
+            Some(metadata.len())
+        } else {
+            None
+        };
+
         let name = path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
@@ -47,33 +78,50 @@ impl<'a> TreeBuilder<'a> {
         let mut node = TreeNode {
             name,
             path: path.to_path_buf(),
-            is_dir,
+            node_type,
             size,
             children: Vec::new(),
         };
 
-        if is_dir {
-            self.stats.add_dirs(1);
-            // Only traverse directory if within max_depth
-            if let Some(max_depth) = self.args.max_depth {
-                let current_depth = path
-                    .strip_prefix(&self.root)
-                    .map(|p| {
-                        p.components()
-                            .filter(|c| matches!(c, std::path::Component::Normal(_)))
-                            .count()
-                    })
-                    .unwrap_or(0);
-                if current_depth < max_depth {
+        match node.node_type {
+            NodeType::Directory => {
+                let canonical_path = path.canonicalize()?;
+                if self.visited.contains(&canonical_path) {
+                    return Ok(node);
+                }
+                self.visited.insert(canonical_path);
+
+                self.stats.add_dirs(1);
+                // Only traverse directory if within max_depth
+                if let Some(max_depth) = self.args.max_depth {
+                    let current_depth = path
+                        .strip_prefix(&self.root)
+                        .map(|p| {
+                            p.components()
+                                .filter(|c| matches!(c, std::path::Component::Normal(_)))
+                                .count()
+                        })
+                        .unwrap_or(0);
+                    if current_depth < max_depth {
+                        node.children = self.read_dir(path)?;
+                    }
+                } else {
                     node.children = self.read_dir(path)?;
                 }
-            } else {
-                node.children = self.read_dir(path)?;
             }
-        } else {
-            self.stats.add_files(1);
-            if let Some(size) = size {
-                self.stats.add_byte_size(size);
+
+            NodeType::File => {
+                self.stats.add_files(1);
+                if let Some(size) = size {
+                    self.stats.add_byte_size(size);
+                }
+            }
+
+            NodeType::SymbolicLink => {
+                self.stats.add_files(1); // Treat symlinks as files for stats
+                if let Some(size) = size {
+                    self.stats.add_byte_size(size);
+                }
             }
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -110,15 +110,8 @@ impl<'a> TreeBuilder<'a> {
                 }
             }
 
-            NodeType::File => {
+            NodeType::File | NodeType::SymbolicLink => {
                 self.stats.add_files(1);
-                if let Some(size) = size {
-                    self.stats.add_byte_size(size);
-                }
-            }
-
-            NodeType::SymbolicLink => {
-                self.stats.add_files(1); // Treat symlinks as files for stats
                 if let Some(size) = size {
                     self.stats.add_byte_size(size);
                 }


### PR DESCRIPTION
Implement support for symbolic links in the file system tree representation. This includes defining a new `NodeType` for symbolic links and updating the `TreeNode` structure accordingly. The display name for symbolic links is formatted to show the link target. The tree building process now correctly identifies and processes symbolic links, ensuring accurate statistics are maintained.

Fixes #5