### PR TITLE
Add support for ANSI styles and colors with no_color option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ pub struct Args {
     pub format: OutputFormat,
 
     /// Disable ANSI colors
-    #[clap(long, alias="plain", default_value_t = std::env::var("NO_COLOR").is_ok_and(|v| v.to_lowercase() == "true"))]
+    #[clap(long, alias="plain", default_value_t = std::env::var("NO_COLOR").is_ok())]
     pub no_color: bool,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,10 @@ pub struct Args {
     /// The output format to use (text, json, xml)
     #[clap(long, default_value = "text")]
     pub format: OutputFormat,
+
+    /// Disable ANSI colors
+    #[clap(long, alias="plain", default_value_t = std::env::var("NO_COLOR").is_ok_and(|v| v.to_lowercase() == "true"))]
+    pub no_color: bool,
 }
 
 /// Parses command line arguments into the Args struct

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -26,14 +26,14 @@ impl TextFormatter {
             NodeType::File => {
                 let name = node.name.clone();
                 if ansi {
-                    name.ansi(&[ANSI::BrightGreen])
+                    name.ansi(&[ANSI::BrightWhite])
                 } else {
                     name
                 }
             }
             NodeType::Directory => {
                 if ansi {
-                    format!(" {} ", node.name).ansi(&[ANSI::Bold, ANSI::BgBrightBlue])
+                    format!(" {} ", node.name).ansi(&[ANSI::Bold, ANSI::BgYellow])
                 } else {
                     format!("{}/", node.name)
                 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use crate::cli::Args;
 use crate::helpers;
+use crate::helpers::ansi::{ANSI, ANSIString};
 use crate::tree::{NodeType, TreeNode};
 
 /// Defines the interface for different output formatters
@@ -22,13 +23,15 @@ impl TextFormatter {
     /// Returns the display name for a `TreeNode` based on its type
     fn get_display_name(&self, node: &TreeNode) -> String {
         match node.node_type {
-            NodeType::File => node.name.clone(),
-            NodeType::Directory => format!("{}/", node.name),
+            NodeType::File => node.name.clone().ansi(&[ANSI::BrightWhite]),
+            NodeType::Directory => {
+                format!(" {} ", node.name).ansi(&[ANSI::Bold, ANSI::BgBrightYellow])
+            }
             NodeType::SymbolicLink => {
                 let target = std::fs::read_link(&node.path)
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| "<unreadable>".to_string());
-                format!("{} -> {}", node.name, target)
+                format!("{} -> {}", node.name, target).ansi(&[ANSI::BrightCyan])
             }
         }
     }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,7 +35,7 @@ impl TextFormatter {
                 if ansi {
                     format!(" {} ", node.name).ansi(&[ANSI::Bold, ANSI::BgBrightBlue])
                 } else {
-                    format!(" {} ", node.name)
+                    format!("{}/", node.name)
                 }
             }
             NodeType::SymbolicLink => {

--- a/src/helpers/ansi.rs
+++ b/src/helpers/ansi.rs
@@ -78,27 +78,16 @@ impl std::fmt::Display for ANSI {
 }
 
 pub trait ANSIString {
-    fn ansi(self, codes: &[ANSI]) -> String;
+    fn ansi(&self, codes: &[ANSI]) -> String;
 }
 
-impl ANSIString for &str {
-    fn ansi(self, codes: &[ANSI]) -> String {
+impl<T: AsRef<str>> ANSIString for T {
+    fn ansi(&self, codes: &[ANSI]) -> String {
         let codes_str = codes
             .iter()
             .map(|c| c.to_string())
             .collect::<Vec<_>>()
             .join(";");
-        format!("\u{001b}[{}m{}\u{001b}[0m", codes_str, self)
-    }
-}
-
-impl ANSIString for String {
-    fn ansi(self, codes: &[ANSI]) -> String {
-        let codes_str = codes
-            .iter()
-            .map(|c| c.to_string())
-            .collect::<Vec<_>>()
-            .join(";");
-        format!("\u{001b}[{}m{}\u{001b}[0m", codes_str, &self)
+        format!("\u{001b}[{}m{}\u{001b}[0m", codes_str, self.as_ref())
     }
 }

--- a/src/helpers/ansi.rs
+++ b/src/helpers/ansi.rs
@@ -2,13 +2,15 @@
 // ANSI CODES
 // ----------
 
-/// ANSI escape codes for text formatting
+/// ANSI escape codes
 #[derive(Clone, Copy)]
 #[repr(u8)]
 #[allow(dead_code)]
 pub enum ANSI {
-    // Style codes
+    // Reset all attributes
     Reset = 0,
+
+    // Styles
     Bold,
     Faint,
     Italic,

--- a/src/helpers/ansi.rs
+++ b/src/helpers/ansi.rs
@@ -1,0 +1,104 @@
+// ----------
+// ANSI CODES
+// ----------
+
+/// ANSI escape codes for text formatting
+#[derive(Clone, Copy)]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum ANSI {
+    // Style codes
+    Reset = 0,
+    Bold,
+    Faint,
+    Italic,
+    Underline,
+    BlinkSlow,
+    BlinkRapid,
+    Reverse,
+    Conceal,
+    CrossedOut = 9,
+    NormalIntensity = 22,
+    NotItalic,
+    NotUnderline,
+    NotBlink,
+    NotReverse,
+    NotConceal,
+    NotCrossedOut = 29,
+
+    // Foreground colors
+    Black = 30,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White = 37,
+    Default = 39,
+
+    // Background colors
+    BgBlack = 40,
+    BgRed,
+    BgGreen,
+    BgYellow,
+    BgBlue,
+    BgMagenta,
+    BgCyan,
+    BgWhite,
+    BgDefault = 49,
+
+    // Bright foreground colors
+    BrightBlack = 90,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightMagenta,
+    BrightCyan,
+    BrightWhite,
+    BrightDefault = 99,
+
+    // Bright background colors
+    BgBrightBlack = 100,
+    BgBrightRed,
+    BgBrightGreen,
+    BgBrightYellow,
+    BgBrightBlue,
+    BgBrightMagenta,
+    BgBrightCyan,
+    BgBrightWhite,
+    BgBrightDefault = 109,
+}
+
+impl std::fmt::Display for ANSI {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", *self as u8)
+    }
+}
+
+pub trait ANSIString {
+    fn ansi(self, codes: &[ANSI]) -> String;
+}
+
+impl ANSIString for &str {
+    fn ansi(self, codes: &[ANSI]) -> String {
+        let codes_str = codes
+            .iter()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join(";");
+        format!("\u{001b}[{}m{}\u{001b}[0m", codes_str, self)
+    }
+}
+
+impl ANSIString for String {
+    fn ansi(self, codes: &[ANSI]) -> String {
+        let codes_str = codes
+            .iter()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join(";");
+        format!("\u{001b}[{}m{}\u{001b}[0m", codes_str, &self)
+    }
+}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,1 +1,2 @@
+pub mod ansi;
 pub mod bytes;


### PR DESCRIPTION
Introduce ANSI styles and colors for output formatting, along with a no_color option to disable ANSI colors in the output. This enhances the user experience by allowing customization of the display format.

Fixes #2