### PR TITLE
Create configuration module

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,27 +7,26 @@ use crate::helpers;
 ///
 /// This struct holds the configuration options that can be passed
 /// to the program through command line arguments.
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(author, version, about)]
 pub struct Args {
     /// The directory path to generate the tree from
-    #[clap(default_value = ".")]
-    pub root: std::path::PathBuf,
+    pub root: Option<std::path::PathBuf>,
 
     /// Show full path for each file entry
     #[clap(short, long)]
     pub full_path: bool,
 
     /// The prefix string to use for each level of the tree
-    #[clap(short, long, default_value = "├── ")]
-    pub prefix: String,
+    #[clap(short, long)]
+    pub prefix: Option<String>,
 
     /// The prefix string to use for the last entry of each branch
-    #[clap(short, long, default_value = "└── ")]
-    pub last_prefix: String,
+    #[clap(short, long)]
+    pub last_prefix: Option<String>,
 
-    #[clap(short, long, default_value = "│   ")]
-    pub child_prefix: String,
+    #[clap(short, long)]
+    pub child_prefix: Option<String>,
 
     /// Show all files and directories, including hidden files
     #[clap(short = 'a', long, alias = "all")]
@@ -43,7 +42,7 @@ pub struct Args {
 
     /// Custom ignore files
     #[clap(long, alias = "ignore-file")]
-    pub ignore: Vec<String>,
+    pub ignore: Option<Vec<String>>,
 
     /// Show only directories
     #[clap(long, aliases = ["dir", "folder"])]
@@ -58,19 +57,19 @@ pub struct Args {
     pub size: bool,
 
     /// The format to use for the filesize. e.g. Bytes (B), KiloBytes (KB), MegaBytes (MB), GigaBytes (GB) etc.
-    #[clap(long, default_value = "bytes")]
-    pub size_format: helpers::bytes::Format,
+    #[clap(long)]
+    pub size_format: Option<helpers::bytes::Format>,
 
     /// The maximum depth to recurse
     #[clap(short = 'd', long, aliases = ["depth", "level"])]
     pub max_depth: Option<usize>,
 
     /// The output format to use (text, json, xml)
-    #[clap(long, default_value = "text")]
-    pub format: OutputFormat,
+    #[clap(long)]
+    pub format: Option<OutputFormat>,
 
     /// Disable ANSI colors
-    #[clap(long, alias="plain", default_value_t = std::env::var("NO_COLOR").is_ok())]
+    #[clap(long, alias = "plain")]
     pub no_color: bool,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ pub struct Args {
 
     /// Show full path for each file entry
     #[clap(short, long)]
-    pub full_path: Option<bool>,
+    pub full_path: bool,
 
     /// The prefix string to use for each level of the tree
     #[clap(short, long)]
@@ -32,7 +32,7 @@ pub struct Args {
 
     /// Show all files and directories, including hidden files
     #[clap(short = 'a', long, alias = "all")]
-    pub show_all: Option<bool>,
+    pub show_all: bool,
 
     /// Show only files that match the pattern (glob syntax)
     #[clap(short, long, alias = "pattern")]
@@ -48,15 +48,15 @@ pub struct Args {
 
     /// Show only directories
     #[clap(long, aliases = ["dir", "folder"])]
-    pub directory: Option<bool>,
+    pub directory: bool,
 
     /// Show directory and file count summary
     #[clap(short = 'r', long, alias = "report")]
-    pub summary: Option<bool>,
+    pub summary: bool,
 
     /// Show the filesize next to the name
     #[clap(short, long, alias = "filesize")]
-    pub size: Option<bool>,
+    pub size: bool,
 
     /// The format to use for the filesize. e.g. Bytes (B), KiloBytes (KB), MegaBytes (MB), GigaBytes (GB) etc.
     #[clap(long)]
@@ -72,7 +72,7 @@ pub struct Args {
 
     /// Disable ANSI colors
     #[clap(long, alias = "plain")]
-    pub no_color: Option<bool>,
+    pub no_color: bool,
 
     /// Disables loading the configuration file
     #[clap(long, alias = "nocfg")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,10 @@ pub struct Args {
     /// Disable ANSI colors
     #[clap(long, alias = "plain")]
     pub no_color: Option<bool>,
+
+    /// Disables loading the configuration file
+    #[clap(long, alias = "nocfg")]
+    pub no_config: bool,
 }
 
 /// Parses command line arguments into the Args struct

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+//! Describes the command-line interface
+
 use clap::Parser;
 
 use crate::formatter::OutputFormat;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Args {
 
     /// Show full path for each file entry
     #[clap(short, long)]
-    pub full_path: bool,
+    pub full_path: Option<bool>,
 
     /// The prefix string to use for each level of the tree
     #[clap(short, long)]
@@ -30,7 +30,7 @@ pub struct Args {
 
     /// Show all files and directories, including hidden files
     #[clap(short = 'a', long, alias = "all")]
-    pub show_all: bool,
+    pub show_all: Option<bool>,
 
     /// Show only files that match the pattern (glob syntax)
     #[clap(short, long, alias = "pattern")]
@@ -46,15 +46,15 @@ pub struct Args {
 
     /// Show only directories
     #[clap(long, aliases = ["dir", "folder"])]
-    pub directory: bool,
+    pub directory: Option<bool>,
 
     /// Show directory and file count summary
     #[clap(short = 'r', long, alias = "report")]
-    pub summary: bool,
+    pub summary: Option<bool>,
 
     /// Show the filesize next to the name
     #[clap(short, long, alias = "filesize")]
-    pub size: bool,
+    pub size: Option<bool>,
 
     /// The format to use for the filesize. e.g. Bytes (B), KiloBytes (KB), MegaBytes (MB), GigaBytes (GB) etc.
     #[clap(long)]
@@ -70,7 +70,7 @@ pub struct Args {
 
     /// Disable ANSI colors
     #[clap(long, alias = "plain")]
-    pub no_color: bool,
+    pub no_color: Option<bool>,
 }
 
 /// Parses command line arguments into the Args struct

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,40 +40,36 @@ pub fn merge_configs(file: FileConfig, cli: cli::Args) -> AppConfig {
         root: cli.root.unwrap_or_else(|| PathBuf::from(".")),
 
         // CLI flags are booleans, so they are always present
-        full_path: cli.full_path || file.full_path.unwrap_or(false),
-        show_all: cli.show_all || file.show_all.unwrap_or(false),
-        directory: cli.directory || file.directory.unwrap_or(false),
-        summary: cli.summary || file.summary.unwrap_or(false),
-        size: cli.size || file.size.unwrap_or(false),
-        no_color: cli.no_color || file.no_color.unwrap_or(false),
+        full_path: merge_options(cli.full_path, file.full_path, false),
+        show_all: merge_options(cli.show_all, file.show_all, false),
+        directory: merge_options(cli.directory, file.directory, false),
+        summary: merge_options(cli.summary, file.summary, false),
+        size: merge_options(cli.size, file.size, false),
+        no_color: merge_options(cli.no_color, file.no_color, false),
 
         // CLI > File > Default
-        prefix: cli
-            .prefix
-            .or(file.prefix)
-            .unwrap_or_else(|| "├── ".to_string()),
-        last_prefix: cli
-            .last_prefix
-            .or(file.last_prefix)
-            .unwrap_or_else(|| "└── ".to_string()),
-        child_prefix: cli
-            .child_prefix
-            .or(file.child_prefix)
-            .unwrap_or_else(|| "│   ".to_string()),
+        prefix: merge_options(cli.prefix, file.prefix, "├── ".to_string()),
+        last_prefix: merge_options(cli.last_prefix, file.last_prefix, "└── ".to_string()),
+        child_prefix: merge_options(cli.child_prefix, file.child_prefix, "│   ".to_string()),
 
         // These are optional and can remain None
-        include: cli.include.or(file.include),
-        exclude: cli.exclude.or(file.exclude),
-        max_depth: cli.max_depth.or(file.max_depth),
+        include: merge_options(Some(cli.include), Some(file.include), None),
+        exclude: merge_options(Some(cli.exclude), Some(file.exclude), None),
+        max_depth: merge_options(Some(cli.max_depth), Some(file.max_depth), None),
 
         // CLI > File > Default
-        ignore: cli.ignore.or(file.ignore).unwrap_or_default(),
-        size_format: cli
-            .size_format
-            .or(file.size_format)
-            .unwrap_or(helpers::bytes::Format::Bytes),
-        format: cli.format.or(file.format).unwrap_or(OutputFormat::Text),
+        ignore: merge_options(cli.ignore, file.ignore, Vec::new()),
+        size_format: merge_options(
+            cli.size_format,
+            file.size_format,
+            helpers::bytes::Format::Bytes,
+        ),
+        format: merge_options(cli.format, file.format, OutputFormat::Text),
     }
+}
+
+fn merge_options<T: Clone>(cli: Option<T>, file: Option<T>, default: T) -> T {
+    cli.or(file).unwrap_or(default)
 }
 
 /// Represents the structure of the configuration file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,7 @@ impl Default for Config {
             size_format: helpers::bytes::Format::Bytes,
             max_depth: None,
             format: OutputFormat::Text,
-            no_color: false,
+            no_color: std::env::var("NO_COLOR").is_ok(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,21 +76,21 @@ impl Default for Config {
 #[derive(Default, Debug)]
 pub struct ConfigBuilder {
     pub root: Option<PathBuf>,
-    pub full_path: Option<bool>,
+    pub full_path: bool,
     pub prefix: Option<String>,
     pub last_prefix: Option<String>,
     pub child_prefix: Option<String>,
-    pub show_all: Option<bool>,
+    pub show_all: bool,
     pub include: Option<String>,
     pub exclude: Option<String>,
     pub ignore: Option<Vec<String>>,
-    pub directory: Option<bool>,
-    pub summary: Option<bool>,
-    pub size: Option<bool>,
+    pub directory: bool,
+    pub summary: bool,
+    pub size: bool,
     pub size_format: Option<helpers::bytes::Format>,
     pub max_depth: Option<usize>,
     pub format: Option<OutputFormat>,
-    pub no_color: Option<bool>,
+    pub no_color: bool,
 }
 
 impl ConfigBuilder {
@@ -98,21 +98,21 @@ impl ConfigBuilder {
     /// This effectively means `self` (e.g., CLI) overrides `other` (e.g., file).
     pub fn merge(mut self, other: ConfigBuilder) -> Self {
         self.root = self.root.or(other.root);
-        self.full_path = self.full_path.or(other.full_path);
+        self.full_path = self.full_path || other.full_path;
         self.prefix = self.prefix.or(other.prefix);
         self.last_prefix = self.last_prefix.or(other.last_prefix);
         self.child_prefix = self.child_prefix.or(other.child_prefix);
-        self.show_all = self.show_all.or(other.show_all);
+        self.show_all = self.show_all || other.show_all;
         self.include = self.include.or(other.include);
         self.exclude = self.exclude.or(other.exclude);
         self.ignore = self.ignore.or(other.ignore);
-        self.directory = self.directory.or(other.directory);
-        self.summary = self.summary.or(other.summary);
-        self.size = self.size.or(other.size);
+        self.directory = self.directory || other.directory;
+        self.summary = self.summary || other.summary;
+        self.size = self.size || other.size;
         self.size_format = self.size_format.or(other.size_format);
         self.max_depth = self.max_depth.or(other.max_depth);
         self.format = self.format.or(other.format);
-        self.no_color = self.no_color.or(other.no_color);
+        self.no_color = self.no_color || other.no_color;
         self
     }
 
@@ -121,21 +121,21 @@ impl ConfigBuilder {
         let default_config = Config::default();
         Config {
             root: self.root.unwrap_or(default_config.root),
-            full_path: self.full_path.unwrap_or(default_config.full_path),
+            full_path: self.full_path || default_config.full_path,
             prefix: self.prefix.unwrap_or(default_config.prefix),
             last_prefix: self.last_prefix.unwrap_or(default_config.last_prefix),
             child_prefix: self.child_prefix.unwrap_or(default_config.child_prefix),
-            show_all: self.show_all.unwrap_or(default_config.show_all),
+            show_all: self.show_all || default_config.show_all,
             include: self.include.or(default_config.include),
             exclude: self.exclude.or(default_config.exclude),
             ignore: self.ignore.unwrap_or(default_config.ignore),
-            directory: self.directory.unwrap_or(default_config.directory),
-            summary: self.summary.unwrap_or(default_config.summary),
-            size: self.size.unwrap_or(default_config.size),
+            directory: self.directory || default_config.directory,
+            summary: self.summary || default_config.summary,
+            size: self.size || default_config.size,
             size_format: self.size_format.unwrap_or(default_config.size_format),
             max_depth: self.max_depth.or(default_config.max_depth),
             format: self.format.unwrap_or(default_config.format),
-            no_color: self.no_color.unwrap_or(default_config.no_color),
+            no_color: self.no_color || default_config.no_color,
         }
     }
 }
@@ -171,21 +171,21 @@ impl From<cli::Args> for ConfigBuilder {
 #[derive(Deserialize, Default, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct FileConfig {
-    pub full_path: Option<bool>,
+    pub full_path: bool,
     pub prefix: Option<String>,
     pub last_prefix: Option<String>,
     pub child_prefix: Option<String>,
-    pub show_all: Option<bool>,
+    pub show_all: bool,
     pub include: Option<String>,
     pub exclude: Option<String>,
     pub ignore: Option<Vec<String>>,
-    pub directory: Option<bool>,
-    pub summary: Option<bool>,
-    pub size: Option<bool>,
+    pub directory: bool,
+    pub summary: bool,
+    pub size: bool,
     pub size_format: Option<helpers::bytes::Format>,
     pub max_depth: Option<usize>,
     pub format: Option<OutputFormat>,
-    pub no_color: Option<bool>,
+    pub no_color: bool,
 }
 
 /// Converts FileConfig into a ConfigBuilder

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
-//! Handles loading configuration from a file.
+//! Configuration management for `fstree`.
 //!
-//! This module defines the structure for the configuration file and provides
-//! a function to load it from a standard location (`~/.config/fstree/config.json`).
+//! This module handles loading, merging, and providing access to the application's
+//! configuration, which can be sourced from a configuration file (e.g., `~/.config/fstree/config.json`)
+//! and command-line arguments.
 
 use serde::Deserialize;
 use std::fs;
@@ -68,6 +69,7 @@ pub fn merge(file: FileConfig, cli: cli::Args) -> Config {
     }
 }
 
+/// Merges three optional values, prioritizing CLI, then file, then a default value.
 fn merge_options<T: Clone>(cli: Option<T>, file: Option<T>, default: T) -> T {
     cli.or(file).unwrap_or(default)
 }
@@ -106,8 +108,7 @@ pub struct FileConfig {
 ///
 /// The path is standardized to `~/.config/fstree/config.json` for all platforms.
 fn get_config_path() -> Option<PathBuf> {
-    // Using `home::home_dir()` would be simpler but adds a dependency.
-    // This manual implementation is a good compromise.
+    
     let home_dir = if cfg!(windows) {
         std::env::var("USERPROFILE").ok()
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,42 +171,42 @@ impl From<cli::Args> for ConfigBuilder {
 #[derive(Deserialize, Default, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct FileConfig {
-    pub full_path: bool,
+    pub full_path: Option<bool>,
     pub prefix: Option<String>,
     pub last_prefix: Option<String>,
     pub child_prefix: Option<String>,
-    pub show_all: bool,
+    pub show_all: Option<bool>,
     pub include: Option<String>,
     pub exclude: Option<String>,
     pub ignore: Option<Vec<String>>,
-    pub directory: bool,
-    pub summary: bool,
-    pub size: bool,
+    pub directory: Option<bool>,
+    pub summary: Option<bool>,
+    pub size: Option<bool>,
     pub size_format: Option<helpers::bytes::Format>,
     pub max_depth: Option<usize>,
     pub format: Option<OutputFormat>,
-    pub no_color: bool,
+    pub no_color: Option<bool>,
 }
 
 /// Converts FileConfig into a ConfigBuilder
 impl From<FileConfig> for ConfigBuilder {
     fn from(file_config: FileConfig) -> Self {
         ConfigBuilder {
-            full_path: file_config.full_path,
+            full_path: file_config.full_path.unwrap_or_default(),
             prefix: file_config.prefix,
             last_prefix: file_config.last_prefix,
             child_prefix: file_config.child_prefix,
-            show_all: file_config.show_all,
+            show_all: file_config.show_all.unwrap_or_default(),
             include: file_config.include,
             exclude: file_config.exclude,
             ignore: file_config.ignore,
-            directory: file_config.directory,
-            summary: file_config.summary,
-            size: file_config.size,
+            directory: file_config.directory.unwrap_or_default(),
+            summary: file_config.summary.unwrap_or_default(),
+            size: file_config.size.unwrap_or_default(),
             size_format: file_config.size_format,
             max_depth: file_config.max_depth,
             format: file_config.format,
-            no_color: file_config.no_color,
+            no_color: file_config.no_color.unwrap_or_default(),
             // Root is not part of FileConfig, so it remains None
             root: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,12 @@ fn merge_options<T: Clone>(cli: Option<T>, file: Option<T>, default: T) -> T {
     cli.or(file).unwrap_or(default)
 }
 
+impl From<cli::Args> for Config {
+    fn from(value: cli::Args) -> Self {
+        return merge_configs(FileConfig::default(), value);
+    }
+}
+
 /// Represents the structure of the configuration file.
 ///
 /// Fields are optional, allowing users to only specify the settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
 /// Merges settings from the config file and CLI arguments.
 ///
 /// CLI arguments take precedence over the config file, which takes precedence over defaults.
-pub fn merge_configs(file: FileConfig, cli: cli::Args) -> Config {
+pub fn merge(file: FileConfig, cli: cli::Args) -> Config {
     Config {
         // CLI > File > Default
         root: cli.root.unwrap_or_else(|| PathBuf::from(".")),
@@ -74,7 +74,7 @@ fn merge_options<T: Clone>(cli: Option<T>, file: Option<T>, default: T) -> T {
 
 impl From<cli::Args> for Config {
     fn from(value: cli::Args) -> Self {
-        return merge_configs(FileConfig::default(), value);
+        return merge(FileConfig::default(), value);
     }
 }
 
@@ -126,7 +126,7 @@ fn get_config_path() -> Option<PathBuf> {
 ///
 /// Reads and parses the JSON configuration file. If the file doesn't exist,
 /// is inaccessible, or contains invalid JSON, it returns a default, empty configuration.
-pub fn load() -> FileConfig {
+pub fn load_file() -> FileConfig {
     if let Some(path) = get_config_path() {
         if let Ok(content) = fs::read_to_string(&path) {
             // Ignore empty or whitespace-only config files

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use crate::formatter::OutputFormat;
 use crate::helpers;
 
 /// Represents the final, merged configuration from all sources.
-pub struct AppConfig {
+pub struct Config {
     pub root: PathBuf,
     pub full_path: bool,
     pub prefix: String,
@@ -34,8 +34,8 @@ pub struct AppConfig {
 /// Merges settings from the config file and CLI arguments.
 ///
 /// CLI arguments take precedence over the config file, which takes precedence over defaults.
-pub fn merge_configs(file: FileConfig, cli: cli::Args) -> AppConfig {
-    AppConfig {
+pub fn merge_configs(file: FileConfig, cli: cli::Args) -> Config {
+    Config {
         // CLI > File > Default
         root: cli.root.unwrap_or_else(|| PathBuf::from(".")),
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,82 @@
+//! Handles loading configuration from a file.
+//!
+//! This module defines the structure for the configuration file and provides
+//! a function to load it from a standard location (`~/.config/fstree/config.json`).
+
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::formatter::OutputFormat;
+use crate::helpers;
+
+/// Represents the structure of the configuration file.
+///
+/// Fields are optional, allowing users to only specify the settings
+/// they want to override.
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct FileConfig {
+    pub full_path: Option<bool>,
+    pub prefix: Option<String>,
+    pub last_prefix: Option<String>,
+    pub child_prefix: Option<String>,
+    pub show_all: Option<bool>,
+    pub include: Option<String>,
+    pub exclude: Option<String>,
+    pub ignore: Option<Vec<String>>,
+    pub directory: Option<bool>,
+    pub summary: Option<bool>,
+    pub size: Option<bool>,
+    pub size_format: Option<helpers::bytes::Format>,
+    pub max_depth: Option<usize>,
+    pub format: Option<OutputFormat>,
+    pub no_color: Option<bool>,
+}
+
+/// Returns the path to the configuration file.
+///
+/// The path is standardized to `~/.config/fstree/config.json` for all platforms.
+fn get_config_path() -> Option<PathBuf> {
+    // Using `home::home_dir()` would be simpler but adds a dependency.
+    // This manual implementation is a good compromise.
+    let home_dir = if cfg!(windows) {
+        std::env::var("USERPROFILE").ok()
+    } else {
+        std::env::var("HOME").ok()
+    };
+
+    home_dir.map(|dir| {
+        Path::new(&dir)
+            .join(".config")
+            .join("fstree")
+            .join("config.json")
+    })
+}
+
+/// Loads the configuration from the file system.
+///
+/// Reads and parses the JSON configuration file. If the file doesn't exist,
+/// is inaccessible, or contains invalid JSON, it returns a default, empty configuration.
+pub fn load() -> FileConfig {
+    if let Some(path) = get_config_path() {
+        if let Ok(content) = fs::read_to_string(&path) {
+            // Ignore empty or whitespace-only config files
+            if content.trim().is_empty() {
+                return FileConfig::default();
+            }
+            // Attempt to parse the config, printing an error if it fails.
+            match serde_json::from_str(&content) {
+                Ok(config) => return config,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Failed to parse config file at '{}': {}",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+    }
+    FileConfig::default()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,10 @@ use std::path::{Path, PathBuf};
 
 use crate::cli;
 use crate::formatter::OutputFormat;
-use crate::helpers;
+use crate::helpers::{
+    self,
+    ansi::{ANSI, ANSIString},
+};
 
 /// Represents the final, merged configuration from all sources
 pub struct Config {
@@ -247,7 +250,9 @@ pub fn load_file() -> FileConfig {
                 Ok(config) => return config,
                 Err(e) => {
                     eprintln!(
-                        "Warning: Failed to parse config file at '{}': {}",
+                        "{} {} {}: {}",
+                        " Warning ".ansi(&[ANSI::BgYellow]),
+                        "Failed to parse config file at",
                         path.display(),
                         e
                     );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -15,16 +15,16 @@ pub struct FileFilter {
 }
 
 impl FileFilter {
-    pub fn new(args: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(cfg: &Config) -> Result<Self, Box<dyn std::error::Error>> {
         // Compile pattern matchers
-        let include_pattern = args
+        let include_pattern = cfg
             .include
             .as_ref()
             .map(|pat| Glob::new(pat))
             .transpose()?
             .map(|g| g.compile_matcher());
 
-        let exclude_pattern = args
+        let exclude_pattern = cfg
             .exclude
             .as_ref()
             .map(|pat| Glob::new(pat))
@@ -32,12 +32,12 @@ impl FileFilter {
             .map(|g| g.compile_matcher());
 
         Ok(Self {
-            root: args.root.clone(),
-            only_directories: args.directory,
-            show_all: args.show_all,
+            root: cfg.root.clone(),
+            only_directories: cfg.directory,
+            show_all: cfg.show_all,
             include_pattern,
             exclude_pattern,
-            ignorer: Self::setup_gitignore(&args.root, &args.ignore)?,
+            ignorer: Self::setup_gitignore(&cfg.root, &cfg.ignore)?,
         })
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use globset::{Glob, GlobMatcher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
-use crate::config::AppConfig;
+use crate::config::Config;
 
 pub struct FileFilter {
     root: PathBuf,
@@ -15,7 +15,7 @@ pub struct FileFilter {
 }
 
 impl FileFilter {
-    pub fn new(args: &AppConfig) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(args: &Config) -> Result<Self, Box<dyn std::error::Error>> {
         // Compile pattern matchers
         let include_pattern = args
             .include

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use globset::{Glob, GlobMatcher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
-use crate::cli::Args;
+use crate::AppConfig;
 
 pub struct FileFilter {
     root: PathBuf,
@@ -15,7 +15,7 @@ pub struct FileFilter {
 }
 
 impl FileFilter {
-    pub fn new(args: &Args) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(args: &AppConfig) -> Result<Self, Box<dyn std::error::Error>> {
         // Compile pattern matchers
         let include_pattern = args
             .include

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use globset::{Glob, GlobMatcher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
-use crate::AppConfig;
+use crate::config::AppConfig;
 
 pub struct FileFilter {
     root: PathBuf,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::config::AppConfig;
+use crate::config::Config;
 use crate::helpers;
 use crate::helpers::ansi::{ANSI, ANSIString};
 use crate::tree::{NodeType, TreeNode};
@@ -11,7 +11,7 @@ pub trait Formatter {
     fn format(
         &self,
         node: &TreeNode,
-        args: &AppConfig,
+        args: &Config,
         stats: &crate::stats::Statistics,
     ) -> io::Result<String>;
 }
@@ -25,13 +25,7 @@ impl TextFormatter {
     /// `prefix`: The indentation string for the current level. (Used in recursive calls)
     /// `is_last`: True if the node is the last child of its parent, influencing branch characters
     /// `args`: The command line arguments that control formatting options
-    fn format_node(
-        &self,
-        node: &TreeNode,
-        prefix: &str,
-        is_last: bool,
-        args: &AppConfig,
-    ) -> String {
+    fn format_node(&self, node: &TreeNode, prefix: &str, is_last: bool, args: &Config) -> String {
         let mut output = String::new();
 
         // Determine the correct branch character (├── or └──)
@@ -117,7 +111,7 @@ impl Formatter for TextFormatter {
     fn format(
         &self,
         node: &TreeNode,
-        args: &AppConfig,
+        args: &Config,
         stats: &crate::stats::Statistics,
     ) -> io::Result<String> {
         let mut output = String::new();
@@ -165,7 +159,7 @@ impl Formatter for JsonFormatter {
     fn format(
         &self,
         node: &TreeNode,
-        _args: &AppConfig,
+        _args: &Config,
         stats: &crate::stats::Statistics,
     ) -> io::Result<String> {
         let output = serde_json::json!({

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::AppConfig;
+use crate::config::AppConfig;
 use crate::helpers;
 use crate::helpers::ansi::{ANSI, ANSIString};
 use crate::tree::{NodeType, TreeNode};
@@ -25,7 +25,13 @@ impl TextFormatter {
     /// `prefix`: The indentation string for the current level. (Used in recursive calls)
     /// `is_last`: True if the node is the last child of its parent, influencing branch characters
     /// `args`: The command line arguments that control formatting options
-    fn format_node(&self, node: &TreeNode, prefix: &str, is_last: bool, args: &AppConfig) -> String {
+    fn format_node(
+        &self,
+        node: &TreeNode,
+        prefix: &str,
+        is_last: bool,
+        args: &AppConfig,
+    ) -> String {
         let mut output = String::new();
 
         // Determine the correct branch character (├── or └──)

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -11,7 +11,7 @@ pub trait Formatter {
     fn format(
         &self,
         node: &TreeNode,
-        args: &Config,
+        cfg: &Config,
         stats: &crate::stats::Statistics,
     ) -> io::Result<String>;
 }
@@ -24,29 +24,29 @@ impl TextFormatter {
     ///
     /// `prefix`: The indentation string for the current level. (Used in recursive calls)
     /// `is_last`: True if the node is the last child of its parent, influencing branch characters
-    /// `args`: The command line arguments that control formatting options
-    fn format_node(&self, node: &TreeNode, prefix: &str, is_last: bool, args: &Config) -> String {
+    /// `cfg`: The command line arguments that control formatting options
+    fn format_node(&self, node: &TreeNode, prefix: &str, is_last: bool, cfg: &Config) -> String {
         let mut output = String::new();
 
         // Determine the correct branch character (├── or └──)
         let branch = if is_last {
-            &args.last_prefix
+            &cfg.last_prefix
         } else {
-            &args.prefix
+            &cfg.prefix
         };
 
         // Determine the display name based on the node type
-        let display_name = self.format_display_name(node, !args.no_color);
+        let display_name = self.format_display_name(node, !cfg.no_color);
 
         // Construct the current line with prefix, branch, and name
         let mut line = format!("{}{}{}", prefix, branch, display_name);
 
         // Add file size if requested
-        if args.size {
+        if cfg.size {
             if let Some(size) = node.size {
                 line.push_str(&format!(
                     " ({})",
-                    helpers::bytes::format(size, &args.size_format)
+                    helpers::bytes::format(size, &cfg.size_format)
                 ));
             }
         }
@@ -58,7 +58,7 @@ impl TextFormatter {
         let child_prefix = if is_last {
             format!("{}    ", prefix)
         } else {
-            format!("{}{}", prefix, &args.child_prefix)
+            format!("{}{}", prefix, &cfg.child_prefix)
         };
 
         // Recursively format children
@@ -67,7 +67,7 @@ impl TextFormatter {
                 child,
                 &child_prefix,
                 i == node.children.len() - 1, // Check if this child is the last
-                args,
+                cfg,
             ));
         }
 
@@ -111,20 +111,20 @@ impl Formatter for TextFormatter {
     fn format(
         &self,
         node: &TreeNode,
-        args: &Config,
+        cfg: &Config,
         stats: &crate::stats::Statistics,
     ) -> io::Result<String> {
         let mut output = String::new();
 
         // Handle the root node without any prefix/indentation
-        let mut line = self.format_display_name(node, !args.no_color);
+        let mut line = self.format_display_name(node, !cfg.no_color);
 
         // Add file size to root if requested
-        if args.size {
+        if cfg.size {
             if let Some(size) = node.size {
                 line.push_str(&format!(
                     " ({})",
-                    helpers::bytes::format(size, &args.size_format)
+                    helpers::bytes::format(size, &cfg.size_format)
                 ));
             }
         }
@@ -139,12 +139,12 @@ impl Formatter for TextFormatter {
                 child,
                 "", // Children of the root start with no prefix, format_node handles their indentation
                 i == node.children.len() - 1,
-                args,
+                cfg,
             ));
         }
 
         // Append summary if requested
-        if args.summary {
+        if cfg.summary {
             output.push('\n');
             output.push_str(&stats.to_string());
         }
@@ -159,7 +159,7 @@ impl Formatter for JsonFormatter {
     fn format(
         &self,
         node: &TreeNode,
-        _args: &Config,
+        _cfg: &Config,
         stats: &crate::stats::Statistics,
     ) -> io::Result<String> {
         let output = serde_json::json!({

--- a/src/helpers/bytes.rs
+++ b/src/helpers/bytes.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Format {
     Bytes,
     KiloBytes,
@@ -66,5 +66,15 @@ impl std::str::FromStr for Format {
             "exa" | "exabytes" | "eb" | "e" => Ok(Self::ExaBytes),
             e => Err(format!("Unknown size format: {}", e)),
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Format {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Format>().map_err(serde::de::Error::custom)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,8 @@ fn setup_configuration(args: cli::Args) -> config::Config {
         args.into()
     } else {
         // Load the configuration file and merge it with the command-line arguments
-        let file_config = config::load();
-        config::merge_configs(file_config, args)
+        let config_file = config::load_file();
+        config::merge(config_file, args)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
 }
 
 /// Implementation of the main run logic of the command-line
-fn run(args: &config::AppConfig) -> Result<(), Box<dyn std::error::Error>> {
+fn run(args: &config::Config) -> Result<(), Box<dyn std::error::Error>> {
     // Check if the path actually exists
     if !std::fs::metadata(&args.root).is_ok() {
         return Err(Box::new(std::io::Error::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 //! This program walks through directories and displays their contents in a
 //! hierarchical tree structure, similar to the Unix tree command.
 
+use crate::config::ConfigBuilder;
+
 mod cli;
 mod config;
 mod filter;
@@ -29,11 +31,11 @@ fn main() {
 fn setup_configuration(args: cli::Args) -> config::Config {
     if args.no_config {
         // If `no_config` is set, use only the command-line arguments
-        args.into()
+        ConfigBuilder::from(args).build()
     } else {
         // Load the configuration file and merge it with the command-line arguments
         let config_file = config::load_file();
-        config::merge(config_file, args)
+        ConfigBuilder::from(config_file).merge(args.into()).build()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,30 +11,6 @@ mod helpers;
 mod stats;
 mod tree;
 
-use std::path::PathBuf;
-
-use formatter::OutputFormat;
-
-/// Represents the final, merged configuration from all sources.
-pub struct AppConfig {
-    pub root: PathBuf,
-    pub full_path: bool,
-    pub prefix: String,
-    pub last_prefix: String,
-    pub child_prefix: String,
-    pub show_all: bool,
-    pub include: Option<String>,
-    pub exclude: Option<String>,
-    pub ignore: Vec<String>,
-    pub directory: bool,
-    pub summary: bool,
-    pub size: bool,
-    pub size_format: helpers::bytes::Format,
-    pub max_depth: Option<usize>,
-    pub format: OutputFormat,
-    pub no_color: bool,
-}
-
 /// The main entrypoint of the application
 fn main() {
     // Load configuration from file and command-line arguments
@@ -42,7 +18,7 @@ fn main() {
     let cli_args = cli::parse();
 
     // Merge configurations
-    let app_config = merge_configs(file_config, cli_args);
+    let app_config = config::merge_configs(file_config, cli_args);
 
     if let Err(e) = run(&app_config) {
         eprintln!("Error: {e}");
@@ -50,53 +26,8 @@ fn main() {
     }
 }
 
-/// Merges settings from the config file and CLI arguments.
-///
-/// CLI arguments take precedence over the config file, which takes precedence over defaults.
-fn merge_configs(file: config::FileConfig, cli: cli::Args) -> AppConfig {
-    AppConfig {
-        // CLI > File > Default
-        root: cli.root.unwrap_or_else(|| PathBuf::from(".")),
-
-        // CLI flags are booleans, so they are always present
-        full_path: cli.full_path || file.full_path.unwrap_or(false),
-        show_all: cli.show_all || file.show_all.unwrap_or(false),
-        directory: cli.directory || file.directory.unwrap_or(false),
-        summary: cli.summary || file.summary.unwrap_or(false),
-        size: cli.size || file.size.unwrap_or(false),
-        no_color: cli.no_color || file.no_color.unwrap_or(false),
-
-        // CLI > File > Default
-        prefix: cli
-            .prefix
-            .or(file.prefix)
-            .unwrap_or_else(|| "├── ".to_string()),
-        last_prefix: cli
-            .last_prefix
-            .or(file.last_prefix)
-            .unwrap_or_else(|| "└── ".to_string()),
-        child_prefix: cli
-            .child_prefix
-            .or(file.child_prefix)
-            .unwrap_or_else(|| "│   ".to_string()),
-
-        // These are optional and can remain None
-        include: cli.include.or(file.include),
-        exclude: cli.exclude.or(file.exclude),
-        max_depth: cli.max_depth.or(file.max_depth),
-
-        // CLI > File > Default
-        ignore: cli.ignore.or(file.ignore).unwrap_or_default(),
-        size_format: cli
-            .size_format
-            .or(file.size_format)
-            .unwrap_or(helpers::bytes::Format::Bytes),
-        format: cli.format.or(file.format).unwrap_or(OutputFormat::Text),
-    }
-}
-
 /// Implementation of the main run logic of the command-line
-fn run(args: &AppConfig) -> Result<(), Box<dyn std::error::Error>> {
+fn run(args: &config::AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Check if the path actually exists
     if !std::fs::metadata(&args.root).is_ok() {
         return Err(Box::new(std::io::Error::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,16 +13,27 @@ mod tree;
 
 /// The main entrypoint of the application
 fn main() {
-    // Load configuration from file and command-line arguments
-    let file_config = config::load();
-    let cli_args = cli::parse();
+    // Parse the command-line arguments
+    let args = cli::parse();
 
-    // Merge configurations
-    let app_config = config::merge_configs(file_config, cli_args);
+    // Merge configurations from command-line arguments and configuration file
+    let cfg = setup_configuration(args);
 
-    if let Err(e) = run(&app_config) {
+    if let Err(e) = run(&cfg) {
         eprintln!("Error: {e}");
         std::process::exit(1);
+    }
+}
+
+/// Sets up the configuration for the application
+fn setup_configuration(args: cli::Args) -> config::Config {
+    if args.no_config {
+        // If `no_config` is set, use only the command-line arguments
+        args.into()
+    } else {
+        // Load the configuration file and merge it with the command-line arguments
+        let file_config = config::load();
+        config::merge_configs(file_config, args)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,22 +27,22 @@ fn main() {
 }
 
 /// Implementation of the main run logic of the command-line
-fn run(args: &config::Config) -> Result<(), Box<dyn std::error::Error>> {
+fn run(cfg: &config::Config) -> Result<(), Box<dyn std::error::Error>> {
     // Check if the path actually exists
-    if !std::fs::metadata(&args.root).is_ok() {
+    if !std::fs::metadata(&cfg.root).is_ok() {
         return Err(Box::new(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            format!("path does not exist: {}", &args.root.display().to_string()),
+            format!("path does not exist: {}", &cfg.root.display().to_string()),
         )));
     }
 
     // Build the tree
-    let mut builder = tree::TreeBuilder::new(args)?;
-    let tree = builder.build(&args.root)?;
+    let mut builder = tree::TreeBuilder::new(cfg)?;
+    let tree = builder.build(&cfg.root)?;
 
     // Format and print the tree
-    let formatter = formatter::get_formatter(&args.format);
-    let output = formatter.format(&tree, args, builder.get_stats())?;
+    let formatter = formatter::get_formatter(&cfg.format);
+    let output = formatter.format(&tree, cfg, builder.get_stats())?;
     println!("{}", output);
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn setup_configuration(args: cli::Args) -> config::Config {
     } else {
         // Load the configuration file and merge it with the command-line arguments
         let config_file = config::load_file();
-        ConfigBuilder::from(config_file).merge(args.into()).build()
+        ConfigBuilder::from(args).merge(config_file.into()).build()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,25 +4,101 @@
 //! hierarchical tree structure, similar to the Unix tree command.
 
 mod cli;
+mod config;
 mod filter;
 mod formatter;
 mod helpers;
 mod stats;
 mod tree;
 
+use std::path::PathBuf;
+
+use formatter::OutputFormat;
+
+/// Represents the final, merged configuration from all sources.
+pub struct AppConfig {
+    pub root: PathBuf,
+    pub full_path: bool,
+    pub prefix: String,
+    pub last_prefix: String,
+    pub child_prefix: String,
+    pub show_all: bool,
+    pub include: Option<String>,
+    pub exclude: Option<String>,
+    pub ignore: Vec<String>,
+    pub directory: bool,
+    pub summary: bool,
+    pub size: bool,
+    pub size_format: helpers::bytes::Format,
+    pub max_depth: Option<usize>,
+    pub format: OutputFormat,
+    pub no_color: bool,
+}
+
 /// The main entrypoint of the application
 fn main() {
-    let args = cli::parse();
-    if let Err(e) = run(&args) {
+    // Load configuration from file and command-line arguments
+    let file_config = config::load();
+    let cli_args = cli::parse();
+
+    // Merge configurations
+    let app_config = merge_configs(file_config, cli_args);
+
+    if let Err(e) = run(&app_config) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }
 }
 
+/// Merges settings from the config file and CLI arguments.
+///
+/// CLI arguments take precedence over the config file, which takes precedence over defaults.
+fn merge_configs(file: config::FileConfig, cli: cli::Args) -> AppConfig {
+    AppConfig {
+        // CLI > File > Default
+        root: cli.root.unwrap_or_else(|| PathBuf::from(".")),
+
+        // CLI flags are booleans, so they are always present
+        full_path: cli.full_path || file.full_path.unwrap_or(false),
+        show_all: cli.show_all || file.show_all.unwrap_or(false),
+        directory: cli.directory || file.directory.unwrap_or(false),
+        summary: cli.summary || file.summary.unwrap_or(false),
+        size: cli.size || file.size.unwrap_or(false),
+        no_color: cli.no_color || file.no_color.unwrap_or(false),
+
+        // CLI > File > Default
+        prefix: cli
+            .prefix
+            .or(file.prefix)
+            .unwrap_or_else(|| "├── ".to_string()),
+        last_prefix: cli
+            .last_prefix
+            .or(file.last_prefix)
+            .unwrap_or_else(|| "└── ".to_string()),
+        child_prefix: cli
+            .child_prefix
+            .or(file.child_prefix)
+            .unwrap_or_else(|| "│   ".to_string()),
+
+        // These are optional and can remain None
+        include: cli.include.or(file.include),
+        exclude: cli.exclude.or(file.exclude),
+        max_depth: cli.max_depth.or(file.max_depth),
+
+        // CLI > File > Default
+        ignore: cli.ignore.or(file.ignore).unwrap_or_default(),
+        size_format: cli
+            .size_format
+            .or(file.size_format)
+            .unwrap_or(helpers::bytes::Format::Bytes),
+        format: cli.format.or(file.format).unwrap_or(OutputFormat::Text),
+    }
+}
+
 /// Implementation of the main run logic of the command-line
-fn run(args: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
+fn run(args: &AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Check if the path actually exists
-    if !std::fs::exists(&args.root)? {
+    if !std::fs::metadata(&args.root).is_ok() {
         return Err(Box::new(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             format!("path does not exist: {}", &args.root.display().to_string()),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::config::AppConfig;
+use crate::config::Config;
 use crate::filter::FileFilter;
 use crate::stats::Statistics;
 
@@ -31,7 +31,7 @@ pub struct TreeNode {
 /// The builder responsible for constructing a file system tree based on the provided command line arguments
 pub struct TreeBuilder<'a> {
     /// The command line arguments used to configure the tree building process
-    pub args: &'a AppConfig,
+    pub args: &'a Config,
     /// The root path from which the tree is built
     root: std::path::PathBuf,
     /// The file filter used to determine which files and directories to include in the tree
@@ -44,7 +44,7 @@ pub struct TreeBuilder<'a> {
 
 impl<'a> TreeBuilder<'a> {
     /// Creates a new `TreeBuilder` with the provided command line arguments.
-    pub fn new(args: &'a AppConfig) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(args: &'a Config) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
             root: args.root.clone(),
             args,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::AppConfig;
+use crate::config::AppConfig;
 use crate::filter::FileFilter;
 use crate::stats::Statistics;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -31,7 +31,7 @@ pub struct TreeNode {
 /// The builder responsible for constructing a file system tree based on the provided command line arguments
 pub struct TreeBuilder<'a> {
     /// The command line arguments used to configure the tree building process
-    pub args: &'a Config,
+    pub cfg: &'a Config,
     /// The root path from which the tree is built
     root: std::path::PathBuf,
     /// The file filter used to determine which files and directories to include in the tree
@@ -44,11 +44,11 @@ pub struct TreeBuilder<'a> {
 
 impl<'a> TreeBuilder<'a> {
     /// Creates a new `TreeBuilder` with the provided command line arguments.
-    pub fn new(args: &'a Config) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(cfg: &'a Config) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
-            root: args.root.clone(),
-            args,
-            file_filter: FileFilter::new(args)?,
+            root: cfg.root.clone(),
+            cfg,
+            file_filter: FileFilter::new(cfg)?,
             stats: Statistics::default(),
             visited: HashSet::new(),
         })
@@ -97,7 +97,7 @@ impl<'a> TreeBuilder<'a> {
 
                 self.stats.add_dirs(1);
                 // Only traverse directory if within max_depth
-                if let Some(max_depth) = self.args.max_depth {
+                if let Some(max_depth) = self.cfg.max_depth {
                     let current_depth = path
                         .strip_prefix(&self.root)
                         .map(|p| {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::cli::Args;
+use crate::AppConfig;
 use crate::filter::FileFilter;
 use crate::stats::Statistics;
 
@@ -31,7 +31,7 @@ pub struct TreeNode {
 /// The builder responsible for constructing a file system tree based on the provided command line arguments
 pub struct TreeBuilder<'a> {
     /// The command line arguments used to configure the tree building process
-    pub args: &'a Args,
+    pub args: &'a AppConfig,
     /// The root path from which the tree is built
     root: std::path::PathBuf,
     /// The file filter used to determine which files and directories to include in the tree
@@ -44,7 +44,7 @@ pub struct TreeBuilder<'a> {
 
 impl<'a> TreeBuilder<'a> {
     /// Creates a new `TreeBuilder` with the provided command line arguments.
-    pub fn new(args: &'a Args) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(args: &'a AppConfig) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
             root: args.root.clone(),
             args,


### PR DESCRIPTION
Introduce a configuration module to load settings from a JSON file and merge it with command-line arguments. Refactor the application to utilize the new `AppConfig` structure, enhancing readability and maintainability. Update command-line argument fields to reflect their optional nature.

Fixes #16